### PR TITLE
BugFix of apiRoutes, the right middleware to use is `token-can`

### DIFF
--- a/Http/apiRoutes.php
+++ b/Http/apiRoutes.php
@@ -8,11 +8,11 @@ $router->group(['prefix' => '/slide'], function (Router $router) {
     $router->post('/update', [
         'as' => 'api.slide.update',
         'uses' => 'SlideController@update',
-        'middleware' => 'can:slider.slides.update',
+        'middleware' => 'token-can:slider.slides.update',
     ]);
     $router->post('/delete', [
         'as' => 'api.slide.delete',
         'uses' => 'SlideController@delete',
-        'middleware' => 'can:slider.slides.destroy'
+        'middleware' => 'token-can:slider.slides.destroy'
     ]);
 });


### PR DESCRIPTION
`token-can` use User TokenCan middleware, `can` use  Core Authorization. 