### PR TITLE
Duplicated weight of entire group of sidebar items

### DIFF
--- a/Sidebar/SidebarExtender.php
+++ b/Sidebar/SidebarExtender.php
@@ -32,7 +32,6 @@ class SidebarExtender implements \Maatwebsite\Sidebar\SidebarExtender
     public function extendWith(Menu $menu)
     {
         $menu->group(trans('core::sidebar.content'), function (Group $group) {
-            $group->weight(100);
             $group->item(trans('slider::slider.title'), function (Item $item) {
                 $item->weight(3);
                 $item->icon('fa fa-bars');


### PR DESCRIPTION
`$group->weight(100);` Is already been added to Menu Module SidebarExtender, and should not be repeated.