### PR TITLE
make classes column nullable, due to Laravel middleware behavior

### DIFF
--- a/Database/Migrations/2020_10_03_001700_make_classes_nullable_on_slides.php
+++ b/Database/Migrations/2020_10_03_001700_make_classes_nullable_on_slides.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class MakeClassesNullableOnSlides extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('slider__slides', function (Blueprint $table) {
+            $table->string('classes', 1024)->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('slider__slides', function (Blueprint $table) {
+            $table->string('classes', 1024)->change();
+        });
+    }
+}


### PR DESCRIPTION
when `ConvertEmptyStringsToNull` is active, it replaces empty strings to null, and null values are not allowed on the table. This PR fixes that